### PR TITLE
Fixes the candy and removes the bat's line

### DIFF
--- a/Candy.gd
+++ b/Candy.gd
@@ -1,12 +1,6 @@
-extends KinematicBody2D
+extends Area2D
 
-
-func _ready():
-	pass
-
-
-func _on_Area2D_area_entered(body):
+func _on_Candy_body_entered(body):
 	if body.name == 'Player':
 		Global.save_data["score"] += 10
 		queue_free()
-	

--- a/Candy.tscn
+++ b/Candy.tscn
@@ -1,13 +1,11 @@
-[gd_scene load_steps=5 format=2]
+[gd_scene load_steps=4 format=2]
 
 [ext_resource path="res://Candy.gd" type="Script" id=1]
 [ext_resource path="res://Assets/bean_pink.png" type="Texture" id=2]
 
 [sub_resource type="CircleShape2D" id=1]
 
-[sub_resource type="CircleShape2D" id=2]
-
-[node name="Candy" type="KinematicBody2D"]
+[node name="Candy" type="Area2D"]
 script = ExtResource( 1 )
 
 [node name="Sprite" type="Sprite" parent="."]
@@ -16,9 +14,4 @@ texture = ExtResource( 2 )
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 shape = SubResource( 1 )
 
-[node name="Area2D" type="Area2D" parent="."]
-
-[node name="CollisionShape2D" type="CollisionShape2D" parent="Area2D"]
-shape = SubResource( 2 )
-
-[connection signal="area_entered" from="Area2D" to="." method="_on_Area2D_area_entered"]
+[connection signal="body_entered" from="." to="." method="_on_Candy_body_entered"]

--- a/Enemy/Bat.gd
+++ b/Enemy/Bat.gd
@@ -45,7 +45,7 @@ func _draw():
 	if points.size() > 1:
 		var prev_point = get_global_position()
 		for p in points:
-			draw_line(p - get_global_position(), prev_point - get_global_position(), c, 2)
+			#draw_line(p - get_global_position(), prev_point - get_global_position(), c, 2)
 			prev_point = p
 
 

--- a/Enemy/Bat.tscn
+++ b/Enemy/Bat.tscn
@@ -41,6 +41,7 @@ script = ExtResource( 1 )
 
 [node name="AnimatedSprite" type="AnimatedSprite" parent="."]
 frames = SubResource( 4 )
+frame = 1
 playing = true
 
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]


### PR DESCRIPTION
You made the candy a little more complicated than it needed to be. It should be working now. If you want to reenable the line between the bat and the player, uncomment (remove the # on) line 48.